### PR TITLE
カラムの重複修正

### DIFF
--- a/db/migrate/20200404130015_remove_category_from_items.rb
+++ b/db/migrate/20200404130015_remove_category_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveCategoryFromItems < ActiveRecord::Migration[5.0]
+  def change
+    remove_reference :items, :category, null: false
+  end
+end


### PR DESCRIPTION
##  What
category_idが重複しているため、カラムを削除（カラム削除していたが、そのマイグレーションファイル自体を削除していたのが原因かもです）