### PR TITLE
商品編集機能の調整

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -18,17 +18,32 @@ $(function(){
     fileReader.onloadend = function() {
       var src = fileReader.result
       var html= `
-      <div>
-        <img src="${src}">
-        <div class="destroy">
-          <button type="button">
-            削除
-          </button>
-        </div>
-      </div>
-      `
+                  <img class="img" src="${src}">
+                  <p>画像を変更する場合はブラウザでページを更新してください</p>
+                `
       $('.image_box').append(html);
+      $('.item_image_paragraph').remove();
     }
     fileReader.readAsDataURL(file);
+  });
+
+  $(function btn_change(){
+    $('.add_file').change(function(){
+      var file = $('input[type="file"]').prop('files')[0];
+      var fileReader = new FileReader();
+      fileReader.onloadend = function() {
+        var src = fileReader.result
+        var html= `
+                    <div class="image_box">
+                      <img class="img" src="${src}">
+                      <p>もう一度画像を変更する場合はブラウザでページを更新してください</p>
+                    </div>
+                  `
+        $('.img').remove();
+        $('.btn_change').remove();
+        $('.images_line').append(html);
+      }
+      fileReader.readAsDataURL(file);
+    });
   });
 });

--- a/app/assets/stylesheets/items_sell.scss
+++ b/app/assets/stylesheets/items_sell.scss
@@ -24,23 +24,51 @@
     }
     .item_image {
       margin-bottom: 50px;
-      .image_box{
+      width: 100%;
+      
+      .images_line{
         display: flex;
-        width: 100%;
-        flex-wrap: wrap;  
-        .destroy{
-          text-align: center;
-        }  
-        img{
+        flex-wrap: wrap;
+
+        .image_box{
           display: flex;
-          margin-left: 10px;		   
-          margin-right: 10px;		    
-          margin-bottom: 2px;    
-          border-radius: 5px;		    
-          border: 2px solid #ddd;		   
-          height: 100px;
-          width: 100px;
-        }		   
+          flex-direction: column;
+          
+          .img{
+            display: flex;
+            margin: 2px 10px;
+            height: 100px;
+            width: 100px;
+            display: flex;
+            flex-direction: column;
+          }		   
+          
+          .btn_change{
+            height: 20px;
+            width: 100px;
+            text-align: center;
+            margin: 2px 10px;
+            background-color: gainsboro;
+            opacity: 0.8;
+            font-size: 12px;
+            border: solid 1px;
+            border-radius: 5px;
+            padding: 0px 5px;
+            cursor: pointer;
+            user-select: none;
+            filter: drop-shadow(2px 2px 2px rgba(0,0,0,0.6));
+          }  
+
+          .btn_change:active{
+            opacity: 1.0;
+            cursor: pointer;
+            filter: none;
+          }
+
+          .add_file{
+            display: none;
+          }
+        }
       }		  
       .item_image_paragraph {
         .file-btn {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,10 +40,19 @@ class ItemsController < ApplicationController
   end
 
   def update
-    item = Item.find(params[:id])
-    item.update!(item_params)
-    redirect_to root_path(item.id)
-  
+    @item = Item.find(params[:id])
+    @images = @item.images
+    begin
+      @item.update!(item_params)
+    rescue
+      @item = Item.find(params[:id])
+      @images = @item.images
+      @item.update(except_image)
+    end
+    if @images.length >= 2
+      @images.first.destroy
+    end
+    redirect_to item_path
   end
 
   def show
@@ -51,10 +60,12 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.includes(:images).find(params[:id])
-    @category_parent = ["---"]
-    @category_parent= Category.where(ancestry: nil).each do |parent|
-      @category_parent<<parent.name
+    @category_parent_array = []
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.name
     end
+    @category_child_array = @item.category.parent.parent.children
+    @category_grandchild_array = @item.category.parent.children
   end
 
   def destroy
@@ -114,7 +125,11 @@ class ItemsController < ApplicationController
   private
   
   def item_params
-    params.require(:item).permit(:name,:text,:item_status,:price,:delivery_area,:delivery_charge,:delivery_days,:brand_id,:category_id,images_attributes: [:image]).merge(solder_id: current_user.id)
+    params.require(:item).permit(:name,:text,:item_status,:price,:delivery_area,:delivery_charge,:delivery_days,:brand,:category_id,images_attributes: [:image]).merge(solder_id: current_user.id)
+  end
+
+  def except_image
+    params.require(:item).permit(:name,:text,:item_status,:price,:delivery_area,:delivery_charge,:delivery_days,:brand,:category_id).merge(solder_id: current_user.id)
   end
 
   def set_item_information

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,3 +1,2 @@
 class Brand < ApplicationRecord
-  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,6 @@ class Item < ApplicationRecord
   belongs_to_active_hash :prefecture
 
   belongs_to :category
-  belongs_to :brand, optional: true
   belongs_to :solder, class_name: "User", optional: true
   belongs_to :buyer, class_name: "User", optional: true
   has_many :images,dependent: :destroy

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -9,19 +9,13 @@
         .text
           %p 出品画像
           %span 必須
-        .image_box
-        .item_image_paragraph
-          =f.fields_for :images do |i|
-            = i.label :image, class: "image-file" do
-              .file-btn
-                =icon("fas", "camera",class: "icon")
-                %p 
-                  ドラッグアンドドロップ
-                  %br
-                    またはクリックしてファイルをアップロード
-                =i.file_field :image, class: 'file'
-          - if @item.errors[:images].any?
-            %p.error-message 画像がありません
+        .images_line
+          .image_box{id: "selected_image"}
+            = image_tag @item.images.first.image, class:"img", id: "image"
+            =f.fields_for :images do |i|
+              = i.label :image do
+                .btn_change 変更
+                = i.file_field :image, class: "add_file"
         .input_item_image-new
       .item_name
         .text
@@ -43,9 +37,10 @@
           %p カテゴリー
           %span 必須 
         .item_category_form
-          = f.collection_select :category_id, @category_parent,:id,:name,{include_blank: "選択してください"},{class: "input-select",id: "parent-form"}
-      -if @item.errors[:category].any?
-        %p.error-message-category 選択してください       
+          = f.select :category_id, options_for_select(@category_parent_array.map{|c|[c, {}]}, @item.category.parent.parent.name), {}, {class: 'input-select'}
+          = f.select :category_id, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'input-select'}
+          = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'input-select'}
+          -# = f.text_field :category_id, id: 'grand_child_result_id', type: 'hidden'
       .item_brand
         .text
           %p ブランド

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -2,21 +2,22 @@
   .header_item
     = render "devise/shared/header"
   .body_item
+    .body_item-title
+      %p.title 出品する
     =form_for @item do |f|
       .item_image
         .text
           %p 出品画像
           %span 必須
-        .image_box
+        .images_line
+          .image_box
         .item_image_paragraph
           =f.fields_for :images do |i|
             = i.label :image, class: "image-file" do
               .file-btn
                 =icon("fas", "camera",class: "icon")
                 %p 
-                  ドラッグアンドドロップ
-                  %br
-                    またはクリックしてファイルをアップロード
+                  クリックしてファイルをアップロード
                 =i.file_field :image, class: 'file'
           - if @item.errors[:images].any?
             %p.error-message 画像がありません


### PR DESCRIPTION
## what
- 商品の編集画面で画像を表示させるようにしました。
- 商品の画像の差し替えをできるようにしました。(ただし、編集確定する前に再度画像を差し替える場合はリロードが必要)
- 出品の際のファイルフィールドの文言を修正しました。
- 商品の出品の際に、画像を選択したらファイルフィールドを表示させないようにしました。(1枚のみの投稿であることを明示するため)
- ブランドを入力するとエラーになる不具合を改修しました
## why
- 商品編集画面で画像を差し替えられるようにするため
- viewの調整
- その他、気づいた不具合の修正