### PR TITLE
意図せぬ挙動の修正

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -24,7 +24,7 @@ $(function(){
                   <p>画像を変更する場合はブラウザでページを更新してください</p>
                 `
       $('.image_box').append(html);
-      $('.item_image_paragraph').remove();
+      $('.item_image_paragraph').hide();
     }
     fileReader.readAsDataURL(file);
   });

--- a/app/assets/stylesheets/_devise.scss
+++ b/app/assets/stylesheets/_devise.scss
@@ -1,5 +1,6 @@
 .device.body {
   background-color: lightgray;
+  height: 200%;
   // width: 700px;
   margin: 0 auto;
   padding: 40px 0;

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -3,13 +3,17 @@ class AddressesController < ApplicationController
   before_action :set_address, only: [:edit, :show, :update]
   
   def new
-    @address = Address.new
+    if Address.where(user: current_user).present?
+      redirect_to root_path, alart: 'すでに住所は登録されています'
+    else
+      @address = Address.new
+    end
   end
 
   def create
     @address = Address.create(address_params)
     if @address.save
-      redirect_to root_path
+      redirect_to root_path, alert: 'アカウント情報を登録しました'
     else
       render :new
     end
@@ -24,7 +28,7 @@ class AddressesController < ApplicationController
 
   def update
     if Address.update(address_params)
-      redirect_to "/users/#{current_user.id}"
+      redirect_to "/users/#{current_user.id}", alert: '変更しました'
     else
       render :edit
     end
@@ -36,6 +40,9 @@ class AddressesController < ApplicationController
   end
 
   def set_address
+    if current_user.id != Address.find(params[:id]).user_id
+      redirect_to root_path
+    end
     @address = Address.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -79,29 +79,33 @@ class ItemsController < ApplicationController
 
   def buy_confirmation
     @item = Item.find(params[:id])
-    @address = Address.find(current_user[:id])
-    @prefecture = Prefecture.find(@address[:prefecture])
-    if @card.present?
-      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      customer = Payjp::Customer.retrieve(@card.customer_id)
-      @card_information = customer.cards.retrieve(@card.card_id)
-      @card_brand = @card_information.brand
-      case @card_brand
-      when "Visa"
-        @card_src = "visa.svg"
-      when "JCB"
-        @card_src = "jcb.svg"
-      when "MasterCard"
-        @card_src = "master-card.svg"
-      when "American Express"
-        @card_src = "american_express.svg"
-      when "Diners Club"
-        @card_src = "dinersclub.svg"
-      when "Discover"
-        @card_src = "discover.svg"
+    if Address.where(user: current_user).present?
+      @address = Address.where(user: current_user)
+      @prefecture = Prefecture.find(@address[:prefecture])
+      if @card.present?
+        Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+        customer = Payjp::Customer.retrieve(@card.customer_id)
+        @card_information = customer.cards.retrieve(@card.card_id)
+        @card_brand = @card_information.brand
+        case @card_brand
+        when "Visa"
+          @card_src = "visa.svg"
+        when "JCB"
+          @card_src = "jcb.svg"
+        when "MasterCard"
+          @card_src = "master-card.svg"
+        when "American Express"
+          @card_src = "american_express.svg"
+        when "Diners Club"
+          @card_src = "dinersclub.svg"
+        when "Discover"
+          @card_src = "discover.svg"
+        end
+      else
+        redirect_to new_card_path,alert: 'カード情報を登録してください'
       end
     else
-      redirect_to new_card_path,alert: 'カード情報を登録してください'
+      redirect_to new_address_path,alert: '住所を登録してください'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_category_pull
+  before_action :set_adress
 
   def new
     @user = current_user
@@ -17,5 +18,13 @@ class UsersController < ApplicationController
 
   def set_category_pull
     @parents = Category.where(ancestry: nil).order("id ASC").limit(13)
+  end
+
+  def set_adress
+    if Address.where(user: current_user).present?
+      @address = Address.where(user: current_user)
+    else
+      redirect_to new_address_path, alert: '住所を登録してください'
+    end
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,8 +4,8 @@ class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
  
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
   process resize_to_fit: [100, 100]
 
   # Override the directory where uploaded files will be stored.

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -101,7 +101,7 @@ ja:
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
       new:
         sign_up: アカウント登録
-      signed_up: アカウント登録が完了しました。
+      signed_up: 住所を登録してください
       signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
       signed_up_but_locked: アカウントが凍結されているためログインできません。
       signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。


### PR DESCRIPTION
## what
- サインアップ時のフラッシュメッセージの修正
- userコントローラー、itemコントローラーへのアドレステーブル参照の記載を追加
- addressコントローラーのnewアクションへ条件分岐を追加
- current_user以外の住所情報へアクセスしようとするとroot_pathへredirectするよう修正

## why
以下の挙動を修正するため
●user新規登録は address情報まで登録していなくても「アカウント登録が完了しました。」になる。
●住所情報（必須項目）なしでログインできてしまう。→マイページ、購入機能に影響
●address id を複数取得してしまう。
●他のuserの住所情報の登録、変更が出来てしまう。