### PR TITLE
パスワード2回入力機能の実装

### DIFF
--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -10,7 +10,7 @@
           %h2
             郵便番号
             %span 必須
-          = f.text_field :postcode, class: 'input_box', placeholder: '例)1234567', autofocus: true
+          = f.text_field :postcode, class: 'input_box', placeholder: '例)1234567(ハイフンなし)', autofocus: true
         .group
           %h2
             都道府県

--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -10,7 +10,7 @@
           %h2
             郵便番号
             %span 必須
-          = f.text_field :postcode, class: 'input_box', placeholder: '例)1234567', autofocus: true, id: 'postcode'
+          = f.text_field :postcode, class: 'input_box', placeholder: '例)1234567(ハイフンなし)', autofocus: true, id: 'postcode'
           %p.red#alart_postcode
         .group
           %h2

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -29,6 +29,13 @@
           - if resource.errors[:password].present?
             %p.red パスワードを入力してください
           %p.gray ※英字と数字の両方を含めて設定してください
+        .group
+          %h2
+            パスワード(確認用)
+            %span 必須
+          = f.password_field :password_confirmation, class: 'input_box', placeholder: '確認用'
+          - if resource.errors[:password_confirmation].present?
+            %p.red パスワード(確認用)を入力してください
         %h1 本人確認
         %p 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
         .group


### PR DESCRIPTION
## what
- ユーザー登録画面にパスワード(確認用)の欄を追加
## why
- ユーザーの打ち間違え防止の為